### PR TITLE
Use config file variable in docker-run

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -21,7 +21,7 @@ printf '{
 	},
 	"spmSenderBulkInsertUrl": "%s"
 }' ${SPM_TOKEN} ${NGINX_STATUS_URL} ${PHP_FPM_URL} ${SPM_RECEIVER_URL} > $SPM_AGENT_CONFIG_FILE
- 
+
 export SPM_REPORTED_HOSTNAME=$(docker-info Name)
 echo "Docker Hostname: ${SPM_REPORTED_HOSTNAME}"
-sematext-agent-nginx --config /etc/sematext/sematext-agent-nginx.config 
+sematext-agent-nginx --config $SPM_AGENT_CONFIG_FILE


### PR DESCRIPTION
SPM Agent config is written into config file defined by $SPM_AGENT_CONFIG_FILE, but the agent start is using a hardcoded path